### PR TITLE
Making links optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,12 @@ This is fortunately very easy to accomplish. In the docker.conf file just modify
 **Wait, this is for development, the server is on `localhost` it doesn't work, what now?**
 
 In this case all you need to do is set the server host to `host.docker.internal` and the docker container will know how to communicate with this host. Ie. your database on the localhost.
+
+**I want to only deploy the frontend but it is failing, why?**
+
+If the backend and frontend are deployed it will link the containers together so that they nginx configuration can route any connections to the api container correctly. However if you are only deploying the frontend container then the nginx configuration for that routing will be incorrect. This will cause failure in the creation of the frontend container. To fix this you need to modify the `nginx-config` file by updating the upstream api section to look like follows:
+```
+upstream api {
+    server <API URL>:<API PORT>
+}
+```

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -3,6 +3,10 @@ export VERSION=$1
 git=(${2//:/ })
 apiHost=$3
 CACHEBUST=${VERSION}
+dbLink="--link mr-postgis:db"
+if [[ "$4" = true ]]; then
+    dbLink=""
+fi
 
 cd api
 if [[ "$VERSION" = "LATEST" ]]; then
@@ -22,6 +26,5 @@ fi
 echo "Starting maproulette api container"
 docker run -t --privileged \
         -d -p 9000:9000 \
-        --name maproulette-api \
-        --link mr-postgis:db \
+        --name maproulette-api $dbLink \
         maproulette/maproulette-api:${VERSION}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 
+# Whether to deploy the frontend
 frontend=false
+# What release of the frontend to deploy
 frontendRelease=LATEST
+# The Git location for the frontend
 frontendGit="git:osmlab/maproulette3"
+# Whether to deploy the API
 api=false
+# What release of the API to deploy
 apiRelease=LATEST
+# The Git location for the API
 apiGit="git:maproulette/maproulette2"
+# Whether to wipe the docker database, start clean
 wipeDB=false
+# What port to expose the docker database on, by default will not expose it
 dbPort=""
+# What host the API is on, used for Swagger
 apiHost="maproulette.org"
+# Whether the database being used is external or not. If it is external than won't link and build the database images
+dbExternal=false
+# Whether to link the API and frontend, would only not use this if connecting to another API
+apiExternal=false
 
 while true; do
     case "$1" in
@@ -61,6 +74,12 @@ while true; do
             apiHost=$2
             shift
         ;;
+        --dbExternal)
+            dbExternal=true
+        ;;
+        --apiExternal)
+            apiExternal=true
+        ;;
         *)
             break
         ;;
@@ -71,34 +90,36 @@ done
 echo "API: $api $apiRelease $apiGit"
 echo "FRONTEND: $frontend $frontendRelease $frontendGit"
 if [[ "$api" = true ]]; then
-    echo "deploying database..."
-    if [[ "$wipeDB" == true ]]; then
-        echo "Stopping and removing mr-postgis container"
-        docker stop mr-postgis
-        docker rm mr-postgis
-    fi
+    if [[ "$dbExternal" != true ]]; then
+        echo "deploying database..."
+        if [[ "$wipeDB" == true ]]; then
+            echo "Stopping and removing mr-postgis container"
+            docker stop mr-postgis
+            docker rm mr-postgis
+        fi
 
-    instance=$(docker ps -a | grep mdillon/postgis)
-    if [[ -z "$instance" ]]; then
-        echo "Building new mr-postgis container"
-        docker run $dbPort \
-            --name mr-postgis \
-            -e POSTGRES_DB=mrdata \
-            -e POSTGRES_USER=mrdbuser \
-            -e POSTGRES_PASSWORD=mrdbpass \
-            -d mdillon/postgis
-        sleep 10
-    fi
-    instance=$(docker ps | grep mdillon/postgis)
-    if [[ -z "$instance" ]]; then
-        echo "Restarting mr-postgis container"
-        docker start mr-postgis
+        instance=$(docker ps -a | grep mdillon/postgis)
+        if [[ -z "$instance" ]]; then
+            echo "Building new mr-postgis container"
+            docker run $dbPort \
+                --name mr-postgis \
+                -e POSTGRES_DB=mrdata \
+                -e POSTGRES_USER=mrdbuser \
+                -e POSTGRES_PASSWORD=mrdbpass \
+                -d mdillon/postgis
+            sleep 10
+        fi
+        instance=$(docker ps | grep mdillon/postgis)
+        if [[ -z "$instance" ]]; then
+            echo "Restarting mr-postgis container"
+            docker start mr-postgis
+        fi
     fi
     echo "deploying api..."
-    ./backend/docker.sh $apiRelease $apiGit $apiHost
+    ./api/docker.sh $apiRelease $apiGit $apiHost $dbExternal
     sleep 10
 fi
 if [[ "$frontend" = true ]]; then
     echo "deploying frontend..."
-    ./frontend/docker.sh $frontendRelease $frontendGit $api
+    ./frontend/docker.sh $frontendRelease $frontendGit $apiExternal
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -100,5 +100,5 @@ if [[ "$api" = true ]]; then
 fi
 if [[ "$frontend" = true ]]; then
     echo "deploying frontend..."
-    ./frontend/docker.sh $frontendRelease $frontendGit
+    ./frontend/docker.sh $frontendRelease $frontendGit $api
 fi

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -7,7 +7,7 @@ export VERSION=${VERSION}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
 apiLink=""
-if [[ "$3" = "true" ]]; then
+if [[ "$3" != true ]]; then
     apiLink="--link maproulette-api:api"
 fi
 

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -26,7 +26,6 @@ if [[ $? -eq 0 ]]; then
   docker stop maproulette-frontend || true && docker rm maproulette-frontend || true
 fi
 
-backe
 echo "Starting maproulette frontend container"
 docker run -t --privileged -d -p 3000:80 \
 	--name maproulette-frontend ${apiLink} \

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -6,6 +6,10 @@ fi
 export VERSION=${VERSION}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
+apiLink=""
+if [[ "$3" = "true" ]]; then
+    apiLink="--link maproulette-api:api"
+fi
 
 cd frontend
 if [[ "$VERSION" = "LATEST" ]]; then
@@ -22,9 +26,9 @@ if [[ $? -eq 0 ]]; then
   docker stop maproulette-frontend || true && docker rm maproulette-frontend || true
 fi
 
+backe
 echo "Starting maproulette frontend container"
 docker run -t --privileged -d -p 3000:80 \
-	--name maproulette-frontend \
-	--link maproulette-api:api \
+	--name maproulette-frontend ${apiLink} \
 	maproulette/maproulette-frontend:${VERSION}
 

--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -1,5 +1,5 @@
 upstream api {
-    server host.docker.internal:9000;
+    server api:9000;
 }
 server {
     listen 80 default_server;

--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -1,5 +1,5 @@
 upstream api {
-    server api:9000;
+    server host.docker.internal:9000;
 }
 server {
     listen 80 default_server;


### PR DESCRIPTION
This checkin helps make the links to the database and api containers optional. By default they will be linked.