### PR TITLE
Containers will restart correctly if docker is restarted

### DIFF
--- a/api/bootstrap.sh
+++ b/api/bootstrap.sh
@@ -5,7 +5,8 @@ echo "bootstrap"
 service ssh restart
 
 cd /MapRouletteAPI
-
+# Delete any RUNNING_PID file on restart
+rm RUNNING_PID
 ./setupServer.sh > setupServer.log 2>&1
 
 while true; do sleep 1000; done

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -27,4 +27,5 @@ echo "Starting maproulette api container"
 docker run -t --privileged \
         -d -p 9000:9000 \
         --name maproulette-api $dbLink \
+        -dit --restart unless-stopped \
         maproulette/maproulette-api:${VERSION}

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -29,6 +29,6 @@ fi
 echo "Starting maproulette frontend container"
 docker run -t --privileged -d -p 3000:80 \
 	--name maproulette-frontend ${apiLink} \
-    -git --restart unless-stopped \
+    -dit --restart unless-stopped \
 	maproulette/maproulette-frontend:${VERSION}
 

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -29,5 +29,6 @@ fi
 echo "Starting maproulette frontend container"
 docker run -t --privileged -d -p 3000:80 \
 	--name maproulette-frontend ${apiLink} \
+    -git --restart unless-stopped \
 	maproulette/maproulette-frontend:${VERSION}
 


### PR DESCRIPTION
As the title says, this will make sure that the containers are restarted if the docker daemon is restarted, and especially in the cases where a server is restarted. 

The API container will make sure to rm the RUNNING_PID from the container during the bootstrap phase.