### PR TITLE
Remove deprecated docker --link option

### DIFF
--- a/api/bootstrap.sh
+++ b/api/bootstrap.sh
@@ -6,7 +6,7 @@ service ssh restart
 
 cd /MapRouletteAPI
 # Delete any RUNNING_PID file on restart
-rm RUNNING_PID
+rm RUNNING_PID || true
 ./setupServer.sh > setupServer.log 2>&1
 
 while true; do sleep 1000; done

--- a/api/docker.conf
+++ b/api/docker.conf
@@ -2,7 +2,7 @@ include "application.conf"
 
 #Below are some useful properties to override. 
 db.default {
-  url="jdbc:postgresql://db:5432/mrdata"
+  url="jdbc:postgresql://mr-postgis:5432/mrdata"
   username="mrdbuser"
   password="mrdbpass"
 }

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -3,10 +3,6 @@ export VERSION=$1
 git=(${2//:/ })
 apiHost=$3
 CACHEBUST=${VERSION}
-dbLink="--link mr-postgis:db"
-if [[ "$4" = true ]]; then
-    dbLink=""
-fi
 
 cd api
 if [[ "$VERSION" = "LATEST" ]]; then
@@ -26,6 +22,7 @@ fi
 echo "Starting maproulette api container"
 docker run -t --privileged \
         -d -p 9000:9000 \
-        --name maproulette-api $dbLink \
+        --name maproulette-api \
         -dit --restart unless-stopped \
+        --network mrnet \
         maproulette/maproulette-api:${VERSION}

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -6,10 +6,6 @@ fi
 export VERSION=${VERSION}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
-apiLink=""
-if [[ "$3" != true ]]; then
-    apiLink="--link maproulette-api:api"
-fi
 
 cd frontend
 if [[ "$VERSION" = "LATEST" ]]; then
@@ -28,7 +24,8 @@ fi
 
 echo "Starting maproulette frontend container"
 docker run -t --privileged -d -p 3000:80 \
-	--name maproulette-frontend ${apiLink} \
+	--name maproulette-frontend \
     -dit --restart unless-stopped \
+    --network mrnet \
 	maproulette/maproulette-frontend:${VERSION}
 


### PR DESCRIPTION
Docker has deprecated the --link option used to link 2 containers together for network communication. This has been replaced with creating a bridge network in docker and then linking the containers to the bridge network. Each container can then communicate with the other containers connected to the bridge network just by the name of the container.