### PR TITLE
Set Play session cookie expiration to 7 days

### DIFF
--- a/api/docker.conf
+++ b/api/docker.conf
@@ -23,6 +23,7 @@ play {
     parser.maxDiskBuffer=100M
     parser.maxMemoryBuffer=100M
     session.sameSite=null
+    session.maxAge=7 days
   }
 }
 parsers.MultipartFormData.maxLength=100M


### PR DESCRIPTION
This should mean that the cookie persists across browser window closes, which might help fix https://github.com/osmlab/maproulette3/issues/765.

We might also consider these settings (but I didn't include them in the PR yet):

* `secure = true`: Only send the cookie over HTTPS, in case anyone's using MR from an insecure or public network. Looks like the production site redirects HTTP to HTTPS already, so this should have no effect unless there are paths which don't get redirected.
* `httpOnly = true`: Don't allow Javascript running in the browser to access the cookie, which is a layer of [protection against XSS attacks](https://www.owasp.org/index.php/HttpOnly). Since the cookie is being set by Scala Play and I can't find anywhere it's being decoded by the React app, this looks as if it should be safe to apply.