### PR TITLE
building images before restarting the servers

### DIFF
--- a/api/docker-start.sh
+++ b/api/docker-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export VERSION=$1
+echo "Starting maproulette api container"
+docker run -t --privileged \
+        -d -p 9000:9000 \
+        --name maproulette-api \
+        -dit --restart unless-stopped \
+        --network mrnet \
+        maproulette/maproulette-api:${VERSION}

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -18,11 +18,3 @@ RUNNING=$(docker inspect --format="{{ .State.Running }}" maproulette-api 2> /dev
 if [[ $? -eq 0 ]]; then
   docker stop maproulette-api || true && docker rm maproulette-api || true
 fi
-
-echo "Starting maproulette api container"
-docker run -t --privileged \
-        -d -p 9000:9000 \
-        --name maproulette-api \
-        -dit --restart unless-stopped \
-        --network mrnet \
-        maproulette/maproulette-api:${VERSION}

--- a/deploy.sh
+++ b/deploy.sh
@@ -113,11 +113,22 @@ if [[ "$api" = true ]]; then
             docker start mr-postgis
         fi
     fi
-    echo "deploying api..."
+    echo "building api..."
     ./api/docker.sh $apiRelease $apiGit $apiHost
+fi
+if [[ "$frontend" = true ]]; then
+    echo "building frontend..."
+    ./frontend/docker.sh $frontendRelease $frontendGit
+fi
+
+# Deploy the build docker images
+if [[ "$api" = true ]]; then
+    echo "deploying api..."
+    ./api/docker-start.sh $apiRelease
     sleep 10
 fi
 if [[ "$frontend" = true ]]; then
     echo "deploying frontend..."
-    ./frontend/docker.sh $frontendRelease $frontendGit
+    ./frontend/docker-start.sh $frontendRelease
 fi
+echo "Deployment Complete!"

--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if [[ -z "$VERSION" ]]; then
+	VERSION=$1
+fi
+export VERSION=${VERSION}
+echo "Starting maproulette frontend container"
+docker run -t --privileged -d -p 3000:80 \
+	--name maproulette-frontend \
+    -dit --restart unless-stopped \
+    --network mrnet \
+	maproulette/maproulette-frontend:${VERSION}

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -22,10 +22,3 @@ if [[ $? -eq 0 ]]; then
   docker stop maproulette-frontend || true && docker rm maproulette-frontend || true
 fi
 
-echo "Starting maproulette frontend container"
-docker run -t --privileged -d -p 3000:80 \
-	--name maproulette-frontend \
-    -dit --restart unless-stopped \
-    --network mrnet \
-	maproulette/maproulette-frontend:${VERSION}
-


### PR DESCRIPTION
This PR updates the deployment process slightly, so that it will first build the images, which can take a little bit of time, and then only after both the frontend API images have been built, only then will it stop the current docker containers and restart with the new image.

This allows you to deploy with having very minimal downtime, and really no time when the old UI would be interacting with the new backend.  