### PR TITLE
Stop script execution if there's an error

### DIFF
--- a/api/docker-start.sh
+++ b/api/docker-start.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
+
+set -exuo pipefail
+
 export VERSION=$1
-echo "Stopping and removing maproulette api container"
-RUNNING=$(docker inspect --format="{{ .State.Running }}" maproulette-api 2> /dev/null)
-if [[ $? -eq 0 ]]; then
-  docker stop maproulette-api || true && docker rm maproulette-api || true
+
+if [ "$(docker ps -qa -f name=maproulette-api)" ]; then
+  echo "Removing existing maproulette-api container"
+  docker stop maproulette-api
+  docker rm maproulette-api
 fi
+
 echo "Starting maproulette api container"
-docker run -t --privileged \
-        -d -p 9000:9000 \
-        --name maproulette-api \
-        -dit --restart unless-stopped \
-        --network mrnet \
-        maproulette/maproulette-api:${VERSION}
+docker run \
+  -itd \
+  --name maproulette-api \
+  --network mrnet \
+  --restart unless-stopped \
+  --privileged \
+  -p 9000:9000 \
+  maproulette/maproulette-api:"${VERSION}"

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
+
+set -exuo pipefail
+
 export VERSION=$1
 git=(${2//:/ })
 apiHost=$3
 CACHEBUST=${VERSION}
 
 cd api
-if [[ "$VERSION" = "LATEST" ]]; then
-    CACHEBUST=`git ls-remote https://github.com/maproulette/maproulette2.git | grep HEAD | cut -f 1`
+if [ "$VERSION" = "LATEST" ]; then
+    CACHEBUST=$(git ls-remote https://github.com/maproulette/maproulette2.git | grep HEAD | cut -f 1)
 fi
-echo "Building container for MapRoulette API Version: $VERSION, Repo: ${git[1]}, APIHost: $apiHost"
-docker build -t maproulette/maproulette-api:${VERSION} \
+
+echo "Building container image for MapRoulette API Version: $VERSION, Repo: ${git[1]}, APIHost: $apiHost"
+docker build -t maproulette/maproulette-api:"${VERSION}" \
     --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
-    --build-arg APIHOST="${apiHost}" --build-arg CACHEBUST=${CACHEBUST} .
+    --build-arg APIHOST="${apiHost}" --build-arg CACHEBUST="${CACHEBUST}" .

--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
-if [[ -z "$VERSION" ]]; then
-	VERSION=$1
+
+set -exuo pipefail
+
+# The VERSION can be set with an environment variable. If it's not set, use $1
+export VERSION=${VERSION:-$1}
+
+if [ "$(docker ps -qa -f name=maproulette-frontend)" ]; then
+  echo "Removing existing maproulette-frontend container"
+  docker stop maproulette-frontend
+  docker rm maproulette-frontend
 fi
-export VERSION=${VERSION}
-echo "Stopping and removing maproulette frontend container"
-RUNNING=$(docker inspect --format="{{ .State.Running }}" maproulette-frontend 2> /dev/null)
-if [[ $? -eq 0 ]]; then
-  docker stop maproulette-frontend || true && docker rm maproulette-frontend || true
-fi
+
 echo "Starting maproulette frontend container"
-docker run -t --privileged -d -p 3000:80 \
-	--name maproulette-frontend \
-    -dit --restart unless-stopped \
-    --network mrnet \
-	maproulette/maproulette-frontend:${VERSION}
+docker run \
+  -itd \
+  --name maproulette-frontend \
+  --network mrnet \
+  --restart unless-stopped \
+  --privileged \
+  -p 3000:80 \
+  maproulette/maproulette-frontend:"${VERSION}"

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# environment variables that can be set
-if [[ -z "$VERSION" ]]; then
-	VERSION=$1
-fi
-export VERSION=${VERSION}
+
+set -exuo pipefail
+
+# The VERSION can be set with an environment variable. If it's not set, use $1
+export VERSION=${VERSION:-$1}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
 
 cd frontend
-if [[ "$VERSION" = "LATEST" ]]; then
-    CACHEBUST=`git ls-remote https://github.com/osmlab/maproulette3.git | grep HEAD | cut -f 1`
+if [ "$VERSION" = "LATEST" ]; then
+    CACHEBUST=$(git ls-remote https://github.com/osmlab/maproulette3.git | grep HEAD | cut -f 1)
 fi
-echo "Building maproulette frontend container"
-docker build -t maproulette/maproulette-frontend:${VERSION} \
-        --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
-        --build-arg CACHEBUST=${CACHEBUST} .
 
+echo "Building container image for MapRoulette frontend Version: $VERSION, Repo: ${git[1]}"
+docker build -t maproulette/maproulette-frontend:"${VERSION}" \
+        --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
+        --build-arg CACHEBUST="${CACHEBUST}" .


### PR DESCRIPTION
This patches updates the scripts to stop on error, closing #42, helping to make it more obvious what failed during a deployment. The script output is more verbose with `set -x` and simplifies script debugging.

Here's a short snippet:
```
$ ./deploy.sh -a v4.0.22-rev1 -f v3.7.11-rev1
...
+ echo 'Starting the existing mr-postgis container'
Starting the existing mr-postgis container
+ docker start mr-postgis
mr-postgis
+ echo 'Building api docker image...'
Building api docker image...
+ ./api/docker.sh v4.0.22-rev1 git:maproulette/maproulette2 maproulette.org
+ export VERSION=v4.0.22-rev1
+ VERSION=v4.0.22-rev1
+ git=(${2//:/ })
+ apiHost=maproulette.org
+ CACHEBUST=v4.0.22-rev1
+ cd api
+ '[' v4.0.22-rev1 = LATEST ']'
+ echo 'Building container image for MapRoulette API Version: v4.0.22-rev1, Repo: maproulette/maproulette2, APIHost: maproulette.org'
Building container image for MapRoulette API Version: v4.0.22-rev1, Repo: maproulette/maproulette2, APIHost: maproulette.org
+ docker build -t maproulette/maproulette-api:v4.0.22-rev1 --build-arg VERSION=v4.0.22-rev1 --build-arg GIT=maproulette/maproulette2 --build-arg APIHOST=maproulette.org --build-arg CACHEBUST=v4.0.22-rev1 .
Sending build context to Docker daemon  13.82kB
...
```