### PR TITLE
Fix swagger docs

### DIFF
--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -19,7 +19,7 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_http_version 1.1;
     }
-    location ~ (/api/|/auth/|/docs/) {
+    location ~ (/api/|/auth/|/docs/|/assets/) {
         proxy_pass http://api;
 
         include mime.types;


### PR DESCRIPTION
The /assets within the nginx conf is needed to have working swagger docs. However, `/assets` was removed to fix 404 errors for some browsers loading the favicon.