### PR TITLE
Switch 'docker.conf' to a template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 postgres-data/
+api/application-overrides.conf
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,19 @@ Docker image and deployment scripts for Map Roulette api, database and fronted. 
 
 ### Setting up Configuration
 
-##### API 
-There are a couple of required properties that you will need to setup prior to running the deploy.sh shell script. These settings need to be updated in the `docker.conf` file in the api directory, look for the "CHANGE_ME" fields.
+##### API
+There are a couple of required properties that you will need to setup prior to running `deploy.sh`.
+
+The main application configuration is located within the [maproulette2 repository as application.conf](https://github.com/maproulette/maproulette2/blob/dev/conf/application.conf), and the below will override the originals.
+
+To avoid accidentally checking in private keys, the `api/application-overrides.template.conf` file must be copied as `api/application-overrides.conf`, and at a minimum these settings need to be updated, look for the "CHANGE_ME" fields.
 
 * **db.default.url** - This is the location of the database. This is set to the linked postgres docker container, so doesn't need to be explicitly set unless using a different database. If you are not deploying the Postgres database using Docker then update this field with the connection string to your external database
-* **osm.consumerKey** - This is the consumer key for your MapRoulette application in your openstreetmap.org account. 
+* **osm.consumerKey** - This is the consumer key for your MapRoulette application in your openstreetmap.org account.
 * **osm.consumerSecret** - This is the consumer secret that is found in the same MapRoulette application settings as is the consumer key.
 * **maproulette.super.key** - This is the api key that can be used for any API requests and the server will assume that the person making the request is a super user. No requirement to login.
-* **maproulette.super.accounts** - This is a comma separated list of OSM account ids that will be elevated to super user access when they login. 
-* **maproulette.bootstrap** - Set this to `true` when you build a new MapRoulette API with a new database.  
+* **maproulette.super.accounts** - This is a comma separated list of OSM account ids that will be elevated to super user access when they login.
+* **maproulette.bootstrap** - Set this to `true` when you build a new MapRoulette API with a new database.
 
 ##### Frontend
 The frontend requires certain properties to be updated as well. The properties need to be updated in the `.env.production` file that can be found in the frontend directory. The default properties assume that it is pointing to an instance of the MapRoulette backend that has been deployed by docker. So if you do deploy the backend using the deploy script (docker) then you won't need to change these properties.
@@ -59,7 +63,7 @@ The ordering of your flags does not matter.
 
 **I want to connect to my own database, how do I do that?**
 
-This is fortunately very easy to accomplish. In the docker.conf file just modify the db.default.url property to with the IP of the server that is hosting your database.
+This is fortunately very easy to accomplish. In the `api/application-overrides.conf` file just modify the `db.default.url` property to your database.
 
 **Wait, this is for development, the server is on `localhost` it doesn't work, what now?**
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -55,6 +55,6 @@ USER maproulette
 WORKDIR /MapRouletteAPI
 
 ADD --chown=1000:0 setupServer.sh /MapRouletteAPI/setupServer.sh
-ADD --chown=1000:0 docker.conf /MapRouletteAPI/conf/docker.conf
+ADD --chown=1000:0 application-overrides.conf /MapRouletteAPI/conf/application-overrides.conf
 
 ENTRYPOINT ["./setupServer.sh"]

--- a/api/application-overrides.template.conf
+++ b/api/application-overrides.template.conf
@@ -1,3 +1,9 @@
+#
+# IMPORTANT NOTE:
+#     The main application configuration is located within the [maproulette2 repository](https://github.com/maproulette/maproulette2/blob/dev/conf/application.conf).
+#     Changes in the default configuration should be done in the maproulette2 repository, and not within the below override content.
+#     Please reference the above URL to see all configuration options.
+#
 include "application.conf"
 
 #Below are some useful properties to override. 

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -7,6 +7,12 @@ git=(${2//:/ })
 apiHost=$3
 CACHEBUST=${VERSION}
 
+if [ ! -f "api/application-overrides.conf" ]; then
+    echo "File api/application-overrides.conf does not exist!" >&2
+    echo "Copy api/application-overrides.template.conf and rename it as api/application-overrides.conf, and override as necessary." >&2
+    exit 1
+fi
+
 cd api
 if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/maproulette/maproulette2.git | grep HEAD | cut -f 1)

--- a/api/setupServer.sh
+++ b/api/setupServer.sh
@@ -11,4 +11,4 @@ rm -f RUNNING_PID
 /MapRouletteAPI/bin/maprouletteapi \
 	-Dhttp.port=9000 \
 	-DAPI_HOST="${APIHOST}" \
-	-Dconfig.resource=docker.conf
+	-Dconfig.resource=application-overrides.conf


### PR DESCRIPTION
The old file, 'api/docker.conf', is renamed to 'api/application-overrides.template.conf'.
Users must copy the template file to 'api/application-overrides.conf'
and fill in their custom content.

The deploy process will fail if override file does not exist.

Resolves #55 