### PR TITLE
Switch 'frontend/.env.production' to template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 postgres-data/
 api/application-overrides.conf
-
+frontend/env.production

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ To avoid accidentally checking in private keys, the `api/application-overrides.t
 * **maproulette.bootstrap** - Set this to `true` when you build a new MapRoulette API with a new database.
 
 ##### Frontend
-The frontend requires certain properties to be updated as well. The properties need to be updated in the `.env.production` file that can be found in the frontend directory. The default properties assume that it is pointing to an instance of the MapRoulette backend that has been deployed by docker. So if you do deploy the backend using the deploy script (docker) then you won't need to change these properties.
+The frontend requires certain properties to be updated as well. The main configuration is located within the [maproulette3 repository as .env](https://github.com/osmlab/maproulette3/blob/main/.env), and the below will override the originals.
+
+To avoid accidentally checking in private data, the `frontend/env.template.production` file must be copied as `frontend/env.production`, and updated as necessary.
+
+The env.template.production assume that it is pointing to an instance of the MapRoulette backend that has been deployed by docker. So if you do deploy the backend using the deploy script (docker) then you won't need to change these properties.
 
 * **REACT_APP_BASE_PATH** - This is the root path for the MapRoulette frontend App. Which by default is "/" and wouldn't ordinarily need to be changed.
 * **REACT_APP_URL** - This is the root url for the MapRoulette frontend App. By default it is localhost:3000, the reason for this is that it is generally advisable to front these services with a http server like nginx or Apache webserver. And those web servers would then just proxy requests on port 80 to port 3000. But if you don't need certain features you can change this to port 80 instead and not have it fronted by a web server.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 WORKDIR /maproulette-frontend
 
 # This file is needed for the build process
-ADD .env.production .env.production
+ADD env.production .env.production
 
 # Build the Maproulette Frontend
 ENV NODE_OPTIONS="--max-old-space-size=8192"

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -7,6 +7,12 @@ export VERSION=${VERSION:-$1}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
 
+if [ ! -f "frontend/env.production" ]; then
+    echo "File frontend/env.production does not exist!" >&2
+    echo "Copy frontend/env.template.production and rename it as frontend/env.production, and override as necessary." >&2
+    exit 1
+fi
+
 cd frontend
 if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/osmlab/maproulette3.git | grep HEAD | cut -f 1)

--- a/frontend/env.template.production
+++ b/frontend/env.template.production
@@ -1,3 +1,10 @@
+#
+# IMPORTANT NOTE:
+#     This env.production file overrides the values within [maproulette3 .env contents](https://github.com/osmlab/maproulette3/blob/main/.env)
+#     Please reference the above URL to see all configuration options.
+#
+# The below configuration was written to work as-is with the docker deployment scripts
+#
 REACT_APP_BASE_PATH='/'
 REACT_APP_URL='http://127.0.0.1:3000'
 REACT_APP_MAP_ROULETTE_SERVER_URL='http://127.0.0.1:9000'


### PR DESCRIPTION
The old file, 'frontend/.env.production', is renamed to 'frontend/env.template.production'.
Users must copy the template file to 'frontend/env.production' and fill in their custom content.

The deploy process will fail if override file does not exist.

Resolves #56 