### PR TITLE
Support deploy.sh var overrides in conf.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 postgres-data/
 api/application-overrides.conf
 frontend/env.production
+/conf.sh

--- a/README.md
+++ b/README.md
@@ -32,16 +32,40 @@ The env.template.production assume that it is pointing to an instance of the Map
 
 ### Running deploy.sh
 
-The deploy script can deploy the 3 services that are required for a complete MapRoulette setup. The database, the backend and the frontend. Any combination of the 3 can be deployed as needed using the deploy.sh script. The primary script takes the following parameters:
+The `deploy.sh` script takes care of building and deploying containers for a complete MapRoulette service: database, backend, and frontend.
 
-- **-f | --frontend [RELEASE_VERSION] [GIT]** - Deploys the frontend using docker. If the RELEASE_VERSION is not supplied it will set it to `LATEST` and will pull the latest code from github. If you just want the latest then use "LATEST". If GIT is not supplied then it will use the default `git:osmlab/maproulette3`. The GIT value is optional had has the form `git:<GIT_ORGANIZATION>/<GIT_REPO>`. By using the git option you can deploy maproulette from any repo. Most comon usage would be if you have forked MapRoulette and have changes that may not be ready to be published to the public repo.
-- **-a | --api [RELEASE_VERSION] [GIT]** - Deploys the backend using docker. If the RELEASE_VERSION is not supplied it will set it to `LATEST` and will pull the latest code from github. If you just want the latest then use `LATEST`. Important to note the frontend and backend have different release cycles and different versions. Some frontends may be incompatible with some frontend versions. For GIT options see above. Default value is `git:maproulette/maproulette2`.
-- **--dbPort [PORT]** - This option allows the deployed postgres database to be accessible by some port. The port is required when using this option.
+The services started are dependent on the arguments provided to `deploy.sh` or the customized contents of `conf.sh` (copy the `conf.template.sh` and edit it as needed). The command-line arguments take precedence over the `conf.sh`.
 
-Other deploy options
+The script takes the following parameters:
 
-- **--wipeDB** - This option will wipeout the database image and recreate from scratch. Be careful when using this option as it will wipe out any data in your database. So generally it is a good idea to backup the database prior to doing this.
-- **--apiHost [API URL]** - This option is for the Swagger UI and defines the URL that the API is being deployed on.
+* **-f | --frontend [RELEASE_VERSION] [GIT]** - Deploys the frontend container.
+  * `RELEASE_VERSION` is optional and defaults to `LATEST`, using the latest trunk commit.
+  * `GIT` is optional and defaults to `git:osmlab/maproulette3`. `GIT` has the form `git:<GIT_ORGANIZATION>/<GIT_REPO>`. This is helpful to deploy forked MapRoulette projects from github.
+* **-a | --api [RELEASE_VERSION] [GIT]** - Deploys the backend container.
+  * `RELEASE_VERSION` is optional and defaults to `LATEST`, using the latest trunk commit.
+  * IMPORTANT NOTE: the frontend and backend have different release cycles and different versions. Be sure to use compatible versions of frontend and backend.
+  * `GIT` is optional and defaults to `git:maproulette/maproulette2`. `GIT` has the form `git:<GIT_ORGANIZATION>/<GIT_REPO>`. This is helpful to deploy forked MapRoulette projects from github.
+* **--dbPort [PORT]** - The host system's port to use for the database, defaulting to `127.0.0.1:5432`.
+* **--wipeDB** - This option will stop, remove, and recreate the database container. As the database content is written to the local disk, and not to the container, the recreate of the database **does not destroy its data**.
+* **--apiHost [API URL]** - This option is for the Swagger UI and defines the URL that the API is being deployed on.
+
+If you'd like to avoid using command line arguments, create `conf.sh` with your content.
+For example: to deploy the database, frontend at latest, backend at latest:
+
+```sh
+# Create the frontend using the latest commit
+frontend=true
+frontendRelease=LATEST
+
+# Create the api using the latest commit
+api=true
+apiRelease=LATEST
+apiHost="my-custom-maproulette.org"
+
+# Recreate the database container. Data is not lost since it is a local volume mount.
+wipeDB=false
+dbExternal=false
+```
 
 ##### Examples
 

--- a/conf.template.sh
+++ b/conf.template.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# The variables below are sourced within the 'deploy.sh' script.
+# Override as needed for a deployment.
+# Note that any commandline overrides will take precedence.
+#
+
+# Whether to deploy the frontend
+# frontend=false
+
+# What release of the frontend to deploy
+# frontendRelease=LATEST
+
+# The Git location for the frontend
+# frontendGit="git:osmlab/maproulette3"
+
+# Whether to deploy the API
+# api=false
+
+# What release of the API to deploy
+# apiRelease=LATEST
+
+# The Git location for the API
+# apiGit="git:maproulette/maproulette2"
+
+# Whether to wipe the docker database, start clean
+# wipeDB=false
+
+# Host port to expose the postgis database container. By default bind to localhost:5432 so that pgadmin is able to connect to the database via an ssh tunnel.
+# dbPort="127.0.0.1:5432"
+
+# What host the API is on, used for Swagger
+# apiHost="maproulette.org"
+
+# Whether the database being used is external or not. If it is external than won't link and build the database images
+# dbExternal=false
+
+# Whether to just build the docker images and not deploy them
+# buildOnly=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,28 +2,36 @@
 
 set -exuo pipefail
 
+# If there is a conf.sh, include it to override any of the below variables.
+# Note that any commandline overrides will take precedence.
+if [ -f "conf.sh" ]; then
+    echo "Using variables from conf.sh"
+    # shellcheck source=/dev/null
+    source conf.sh
+fi
+
 # Whether to deploy the frontend
-frontend=false
+frontend=${frontend:-false}
 # What release of the frontend to deploy
-frontendRelease=LATEST
+frontendRelease=${frontendRelease:-LATEST}
 # The Git location for the frontend
-frontendGit="git:osmlab/maproulette3"
+frontendGit=${frontendGit:-"git:osmlab/maproulette3"}
 # Whether to deploy the API
-api=false
+api=${api:-false}
 # What release of the API to deploy
-apiRelease=LATEST
+apiRelease=${apiRelease:-LATEST}
 # The Git location for the API
-apiGit="git:maproulette/maproulette2"
+apiGit=${apiGit:-"git:maproulette/maproulette2"}
 # Whether to wipe the docker database, start clean
-wipeDB=false
+wipeDB=${wipeDB:-false}
 # Host port to expose the postgis database container. By default bind to localhost:5432 so that pgadmin is able to connect to the database via an ssh tunnel.
-dbPort="127.0.0.1:5432"
+dbPort=${dbPort:-"127.0.0.1:5432"}
 # What host the API is on, used for Swagger
-apiHost="maproulette.org"
+apiHost=${apiHost:-"maproulette.org"}
 # Whether the database being used is external or not. If it is external than won't link and build the database images
-dbExternal=false
+dbExternal=${dbExternal:-false}
 # Whether to just build the docker images and not deploy them
-buildOnly=false
+buildOnly=${buildOnly:-false}
 
 # Allow unset varaibles to be used while setting arguments
 set +u
@@ -125,7 +133,7 @@ if [[ "$api" = true ]]; then
                 -e POSTGRES_DB=mrdata \
                 -e POSTGRES_USER=mrdbuser \
                 -e POSTGRES_PASSWORD=mrdbpass \
-                --volume $(pwd)/postgres-data:/var/lib/postgresql/data \
+                --volume "$(pwd)/postgres-data":/var/lib/postgresql/data \
                 postgis/postgis:11-2.5
         fi
     fi


### PR DESCRIPTION
The deployment script doesn't expose all variables to command line, or
it is tedious to provide those command line arguments all the time.
Resolve this by having an optional `conf.sh` to
override the default values seen in the `deploy.sh`.

Note that command-line arguments take precedence over values within
`conf.sh`.

If you'd like to avoid using command line arguments, create `conf.sh` with your content.
For example: to deploy the database, frontend at latest, backend at latest create `conf.sh` (based on `conf.template.sh`:

```sh
# File conf.sh
# Create the frontend using the latest commit
frontend=true
frontendRelease=LATEST

# Create the api using the latest commit
api=true
apiRelease=LATEST
apiHost="my-custom-maproulette.org"

# Recreate the database container. Data is not lost since it is a local volume mount.
wipeDB=false
dbExternal=false
```


Resolves #51 