### PR TITLE
Update to sbt 1.5.8 (using patched log4j 2.17.0)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ ARG OPENJDK_JDK_TAG=11-bullseye # jdk version for compiling the source
 ARG OPENJDK_JRE_TAG=11-jre-bullseye # jre runtime, without the javac compiler, for running the jar
 FROM openjdk:${OPENJDK_JDK_TAG} as builder
 
-ARG SBT_VERSION=1.5.5
+ARG SBT_VERSION=1.5.8
 ARG CACHEBUST=1
 ARG GIT="maproulette/maproulette2"
 ARG VERSION="LATEST"


### PR DESCRIPTION
Update to sbt 1.5.8 which includes the patched version of log4j 2.17.0.
See https://github.com/sbt/sbt/releases/tag/v1.5.8