### PR TITLE
Remove API_HOST variable from swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The script takes the following parameters:
   * `GIT` is optional and defaults to `git:maproulette/maproulette2`. `GIT` has the form `git:<GIT_ORGANIZATION>/<GIT_REPO>`. This is helpful to deploy forked MapRoulette projects from github.
 * **--dbPort [PORT]** - The host system's port to use for the database, defaulting to `127.0.0.1:5432`.
 * **--wipeDB** - This option will stop, remove, and recreate the database container. As the database content is written to the local disk, and not to the container, the recreate of the database **does not destroy its data**.
-* **--apiHost [API URL]** - This option is for the Swagger UI and defines the URL that the API is being deployed on.
 
 If you'd like to avoid using command line arguments, create `conf.sh` with your content.
 For example: to deploy the database, frontend at latest, backend at latest:
@@ -63,7 +62,6 @@ frontendRelease=LATEST
 # Create the api using the latest commit
 api=true
 apiRelease=LATEST
-apiHost="my-custom-maproulette.org"
 
 # Recreate the database container. Data is not lost since it is a local volume mount.
 wipeDB=false

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,7 +25,6 @@ RUN \
     echo "${GIT}" && \
     echo "${CACHEBUST}" && \
     echo "${VERSION}" && \
-    echo "${APIHOST}" && \
     if [ "${VERSION}" = "LATEST" ]; then \
         git clone --depth 1 https://github.com/${GIT}.git /maproulette-api ; \
     else \
@@ -35,14 +34,11 @@ WORKDIR /maproulette-api
 
 RUN \
     echo "\n\nBUILDING API COMMIT $(git rev-parse HEAD)\n\n" && \
-    export API_HOST=${APIHOST} && \
     sbt evicted && \
     sbt clean compile dist && \
     unzip -d / target/universal/MapRouletteAPI.zip
 
 FROM openjdk:${OPENJDK_JRE_TAG}
-ARG APIHOST="maproulette.org"
-ENV APIHOST=${APIHOST}
 
 # Runtime image needs to have the most up-to-date patches
 RUN \

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -4,7 +4,6 @@ set -exuo pipefail
 
 export VERSION=$1
 git=(${2//:/ })
-apiHost=$3
 CACHEBUST=${VERSION}
 
 if [ ! -f "api/application-overrides.conf" ]; then
@@ -18,7 +17,7 @@ if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/maproulette/maproulette2.git | grep HEAD | cut -f 1)
 fi
 
-echo "Building container image for MapRoulette API Version: $VERSION, Repo: ${git[1]}, APIHost: $apiHost"
+echo "Building container image for MapRoulette API Version: $VERSION, Repo: ${git[1]}"
 docker build -t maproulette/maproulette-api:"${VERSION}" \
     --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
-    --build-arg APIHOST="${apiHost}" --build-arg CACHEBUST="${CACHEBUST}" .
+    --build-arg CACHEBUST="${CACHEBUST}" .

--- a/api/setupServer.sh
+++ b/api/setupServer.sh
@@ -2,13 +2,10 @@
 
 set -exu
 
-APIHOST=${APIHOST:-maproulette.org}
-
 # The java process creates RUNNING_PID and it must not exist before attempting to start java.
 # Delete the file just in case the process died and is restarting.
 rm -f RUNNING_PID
 
 /MapRouletteAPI/bin/maprouletteapi \
 	-Dhttp.port=9000 \
-	-DAPI_HOST="${APIHOST}" \
 	-Dconfig.resource=application-overrides.conf

--- a/conf.template.sh
+++ b/conf.template.sh
@@ -29,9 +29,6 @@
 # Host port to expose the postgis database container. By default bind to localhost:5432 so that pgadmin is able to connect to the database via an ssh tunnel.
 # dbPort="127.0.0.1:5432"
 
-# What host the API is on, used for Swagger
-# apiHost="maproulette.org"
-
 # Whether the database being used is external or not. If it is external than won't link and build the database images
 # dbExternal=false
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,8 +26,6 @@ apiGit=${apiGit:-"git:maproulette/maproulette2"}
 wipeDB=${wipeDB:-false}
 # Host port to expose the postgis database container. By default bind to localhost:5432 so that pgadmin is able to connect to the database via an ssh tunnel.
 dbPort=${dbPort:-"127.0.0.1:5432"}
-# What host the API is on, used for Swagger
-apiHost=${apiHost:-"maproulette.org"}
 # Whether the database being used is external or not. If it is external than won't link and build the database images
 dbExternal=${dbExternal:-false}
 # Whether to just build the docker images and not deploy them
@@ -82,10 +80,6 @@ while true; do
         --wipeDB)
             wipeDB=true
         ;;
-        --apiHost)
-            apiHost=$2
-            shift
-        ;;
         --dbExternal)
             dbExternal=true
         ;;
@@ -139,7 +133,7 @@ if [[ "$api" = true ]]; then
     fi
 
     echo "Building api docker image..."
-    ./api/docker.sh "$apiRelease" "$apiGit" "$apiHost"
+    ./api/docker.sh "$apiRelease" "$apiGit"
 fi
 
 if [[ "$frontend" = true ]]; then


### PR DESCRIPTION
The deployment scripts were allowing the swagger `Execute` requests to be sent to a customizable "API host". Since the scala API is what provides the swagger docs there is no need to override the backend API host.

This patch purges the API_HOST variable and the swagger docs will now, by default, send the request to the host where it (the API serving swagger) is running.

If a different host is needed in the future, use this approach https://github.com/iheartradio/play-swagger#how-do-i-use-a-different-host-for-different-environment