### PR TITLE
aarch64 fix: install and link python2

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,11 @@ ARG VERSION="LATEST"
 
 RUN \
     apt-get update && \
-    apt-get install -y jq && \
+    apt-get install -y \
+        jq \
+        python2 \
+    && \
+    ln -sf /usr/bin/python2 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 
 RUN \


### PR DESCRIPTION
The node:14-bullseye image for aarch64 (mac m1 in my case) doesn't include python2, which is required for node-sass.
For now just install python2.

The stack trace for reference:

```
#18 51.87 gyp verb check python checking for Python executable "python2" in the PATH
#18 51.87 gyp verb `which` failed Error: not found: python2
#18 51.87 gyp verb `which` failed     at getNotFoundError (/maproulette-frontend/node_modules/which/which.js:13:12)
#18 51.87 gyp verb `which` failed     at F (/maproulette-frontend/node_modules/which/which.js:68:19)
#18 51.87 gyp verb `which` failed     at E (/maproulette-frontend/node_modules/which/which.js:80:29)
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/which/which.js:89:16
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/index.js:42:5
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/mode.js:8:5
#18 51.87 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:192:21)
#18 51.87 gyp verb `which` failed  python2 Error: not found: python2
#18 51.87 gyp verb `which` failed     at getNotFoundError (/maproulette-frontend/node_modules/which/which.js:13:12)
#18 51.87 gyp verb `which` failed     at F (/maproulette-frontend/node_modules/which/which.js:68:19)
#18 51.87 gyp verb `which` failed     at E (/maproulette-frontend/node_modules/which/which.js:80:29)
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/which/which.js:89:16
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/index.js:42:5
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/mode.js:8:5
#18 51.87 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:192:21) {
#18 51.87 gyp verb `which` failed   code: 'ENOENT'
#18 51.87 gyp verb `which` failed }
#18 51.87 gyp verb check python checking for Python executable "python" in the PATH
#18 51.87 gyp verb `which` failed Error: not found: python
#18 51.87 gyp verb `which` failed     at getNotFoundError (/maproulette-frontend/node_modules/which/which.js:13:12)
#18 51.87 gyp verb `which` failed     at F (/maproulette-frontend/node_modules/which/which.js:68:19)
#18 51.87 gyp verb `which` failed     at E (/maproulette-frontend/node_modules/which/which.js:80:29)
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/which/which.js:89:16
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/index.js:42:5
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/mode.js:8:5
#18 51.87 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:192:21)
#18 51.87 gyp verb `which` failed  python Error: not found: python
#18 51.87 gyp verb `which` failed     at getNotFoundError (/maproulette-frontend/node_modules/which/which.js:13:12)
#18 51.87 gyp verb `which` failed     at F (/maproulette-frontend/node_modules/which/which.js:68:19)
#18 51.87 gyp verb `which` failed     at E (/maproulette-frontend/node_modules/which/which.js:80:29)
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/which/which.js:89:16
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/index.js:42:5
#18 51.87 gyp verb `which` failed     at /maproulette-frontend/node_modules/isexe/mode.js:8:5
#18 51.87 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:192:21) {
#18 51.87 gyp verb `which` failed   code: 'ENOENT'
#18 51.87 gyp verb `which` failed }
#18 51.87 gyp ERR! configure error 
#18 51.87 gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
#18 51.87 gyp ERR! stack     at PythonFinder.failNoPython (/maproulette-frontend/node_modules/node-gyp/lib/configure.js:484:19)
#18 51.87 gyp ERR! stack     at PythonFinder.<anonymous> (/maproulette-frontend/node_modules/node-gyp/lib/configure.js:406:16)
#18 51.87 gyp ERR! stack     at F (/maproulette-frontend/node_modules/which/which.js:68:16)
#18 51.87 gyp ERR! stack     at E (/maproulette-frontend/node_modules/which/which.js:80:29)
#18 51.87 gyp ERR! stack     at /maproulette-frontend/node_modules/which/which.js:89:16
#18 51.87 gyp ERR! stack     at /maproulette-frontend/node_modules/isexe/index.js:42:5
#18 51.87 gyp ERR! stack     at /maproulette-frontend/node_modules/isexe/mode.js:8:5
#18 51.87 gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:192:21)
#18 51.87 gyp ERR! System Linux 5.10.104-linuxkit
#18 51.87 gyp ERR! command "/usr/local/bin/node" "/maproulette-frontend/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
#18 51.87 gyp ERR! cwd /maproulette-frontend/node_modules/node-sass
#18 51.87 gyp ERR! node -v v14.19.3
#18 51.87 gyp ERR! node-gyp -v v3.8.0
#18 51.87 gyp ERR! not ok 
#18 51.87 Build failed with error code: 1
```