### PR TITLE
Support building any tag for API and frontend (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In this case all you need to do is set the server host to `host.docker.internal`
 
 **I want to only deploy the frontend but it is failing, why?**
 
-If the backend and frontend are deployed it will link the containers together so that they nginx configuration can route any connections to the api container correctly. However if you are only deploying the frontend container then the nginx configuration for that routing will be incorrect. This will cause failure in the creation of the frontend container. To fix this you need to modify the `nginx-config` file by updating the upstream api section to look like follows:
+If the backend and frontend are deployed it will link the containers together so that the nginx configuration can route any connections to the api container correctly. However if you are only deploying the frontend container then the nginx configuration for that routing will be incorrect. This will cause failure in the creation of the frontend container. To fix this you need to modify the `nginx-config` file by updating the upstream api section to look like follows:
 ```
 upstream api {
     server <API URL>:<API PORT>

--- a/api/docker-start.sh
+++ b/api/docker-start.sh
@@ -3,6 +3,8 @@
 set -exuo pipefail
 
 export VERSION=$1
+# Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
+export IMAGE_TAG=${VERSION//\//-}
 
 if [ "$(docker ps -qa -f name=maproulette-api)" ]; then
   echo "Removing existing maproulette-api container"
@@ -17,4 +19,4 @@ docker run \
   --network mrnet \
   --restart unless-stopped \
   -p 9000:9000 \
-  maproulette/maproulette-api:"${VERSION}"
+  maproulette/maproulette-api:"${IMAGE_TAG}"

--- a/api/docker.sh
+++ b/api/docker.sh
@@ -3,6 +3,8 @@
 set -exuo pipefail
 
 export VERSION=$1
+# Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
+export IMAGE_TAG=${VERSION//\//-}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
 
@@ -17,7 +19,7 @@ if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/maproulette/maproulette2.git | grep HEAD | cut -f 1)
 fi
 
-echo "Building container image for MapRoulette API Version: $VERSION, Repo: ${git[1]}"
-docker build -t maproulette/maproulette-api:"${VERSION}" \
+echo "Building container image for MapRoulette API Version: $IMAGE_TAG, Repo: ${git[1]}"
+docker build -t maproulette/maproulette-api:"${IMAGE_TAG}" \
     --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
     --build-arg CACHEBUST="${CACHEBUST}" .

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,24 +10,34 @@ if [ -f "conf.sh" ]; then
     source conf.sh
 fi
 
+
 # Whether to deploy the frontend
 frontend=${frontend:-false}
+
 # What release of the frontend to deploy
 frontendRelease=${frontendRelease:-LATEST}
+
 # The Git location for the frontend
 frontendGit=${frontendGit:-"git:osmlab/maproulette3"}
+
 # Whether to deploy the API
 api=${api:-false}
-# What release of the API to deploy
+
+# The API repository's git branch or tag used for the release.
 apiRelease=${apiRelease:-LATEST}
-# The Git location for the API
+
+# The git location for the API
 apiGit=${apiGit:-"git:maproulette/maproulette2"}
+
 # Whether to wipe the docker database, start clean
 wipeDB=${wipeDB:-false}
+
 # Host port to expose the postgis database container. By default bind to localhost:5432 so that pgadmin is able to connect to the database via an ssh tunnel.
 dbPort=${dbPort:-"127.0.0.1:5432"}
+
 # Whether the database being used is external or not. If it is external than won't link and build the database images
 dbExternal=${dbExternal:-false}
+
 # Whether to just build the docker images and not deploy them
 buildOnly=${buildOnly:-false}
 
@@ -55,17 +65,27 @@ while true; do
             done
         ;;
         -a | --api)
+            # Parse the --api arguments. The optional paramters, apiRelease and apiGit, are unordered (and optional!).
+            # The apiGit must start with 'git' (also, any apiRelease branch with 'git' as the prefix cannot be used).
+            #
+            # For example the input could be:
+            # --api
+            # --api [apiRelease]
+            # --api [apiRelease] [apiGit]
+            # --api [apiGit]
+            # --api [apiGit] [apiRelease]
             api=true
-            if [[ $2 =~ ^- ]]; then
-                shift
-                continue
-            fi
             while true; do
+                # If '--api' was provided and a next '--' option was found or no remaining options, means we're done.
+                if [[ "$2" =~ ^- ]] || [ -z $2 ]; then
+                    echo "Arg is empty or starts with a dash"
+                    break
+                fi
                 if [[ "$2" =~ ^git ]]; then
                     apiGit="$2"
                     shift
                     continue
-                elif [[ "$2" = "LATEST" ]] || [[ "$2" =~ ^[0-9v] ]]; then
+                else
                     apiRelease="$2"
                     shift
                     continue

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,17 +46,26 @@ set +u
 while true; do
     case "$1" in
         -f | --frontend)
+            # Parse the --frontend arguments. The optional parameters, frontendRelease and frontendGit, are unordered (and optional!).
+            # The frontendGit must start with 'git' (also, any frontendRelease branch with 'git' as the prefix cannot be used).
+            #
+            # For example the input could be:
+            # --frontend
+            # --frontend [frontendRelease]
+            # --frontend [frontendRelease] [frontendGit]
+            # --frontend [frontendGit]
+            # --frontend [frontendGit] [frontendRelease]
             frontend=true
-            if [[ "$2" =~ ^- ]]; then
-                shift
-                continue
-            fi
             while true; do
+                # If '--frontend' was provided and a next '--' option was found or no remaining options, means we're done.
+                if [[ "$2" =~ ^- ]] || [ -z $2 ]; then
+                    break
+                fi
                 if [[ "$2" =~ ^git ]]; then
                     frontendGit="$2"
                     shift
                     continue
-                elif [[ "$2" = "LATEST" ]] || [[ "$2" =~ ^[0-9v] ]]; then
+                else
                     frontendRelease="$2"
                     shift
                     continue
@@ -65,7 +74,7 @@ while true; do
             done
         ;;
         -a | --api)
-            # Parse the --api arguments. The optional paramters, apiRelease and apiGit, are unordered (and optional!).
+            # Parse the --api arguments. The optional parameters, apiRelease and apiGit, are unordered (and optional!).
             # The apiGit must start with 'git' (also, any apiRelease branch with 'git' as the prefix cannot be used).
             #
             # For example the input could be:
@@ -78,7 +87,6 @@ while true; do
             while true; do
                 # If '--api' was provided and a next '--' option was found or no remaining options, means we're done.
                 if [[ "$2" =~ ^- ]] || [ -z $2 ]; then
-                    echo "Arg is empty or starts with a dash"
                     break
                 fi
                 if [[ "$2" =~ ^git ]]; then

--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -4,6 +4,8 @@ set -exuo pipefail
 
 # The VERSION can be set with an environment variable. If it's not set, use $1
 export VERSION=${VERSION:-$1}
+# Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
+export IMAGE_TAG=${VERSION//\//-}
 
 if [ "$(docker ps -qa -f name=maproulette-frontend)" ]; then
   echo "Removing existing maproulette-frontend container"
@@ -18,4 +20,4 @@ docker run \
   --network mrnet \
   --restart unless-stopped \
   -p 3000:80 \
-  maproulette/maproulette-frontend:"${VERSION}"
+  maproulette/maproulette-frontend:"${IMAGE_TAG}"

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -4,6 +4,8 @@ set -exuo pipefail
 
 # The VERSION can be set with an environment variable. If it's not set, use $1
 export VERSION=${VERSION:-$1}
+# Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
+export IMAGE_TAG=${VERSION//\//-}
 git=(${2//:/ })
 CACHEBUST=${VERSION}
 
@@ -24,7 +26,7 @@ if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/osmlab/maproulette3.git | grep HEAD | cut -f 1)
 fi
 
-echo "Building container image for MapRoulette frontend Version: $VERSION, Repo: ${git[1]}"
-docker build -t maproulette/maproulette-frontend:"${VERSION}" \
+echo "Building container image for MapRoulette frontend Version: $IMAGE_TAG, Repo: ${git[1]}"
+docker build -t maproulette/maproulette-frontend:"${IMAGE_TAG}" \
         --build-arg VERSION="${VERSION}" --build-arg GIT="${git[1]}" \
         --build-arg CACHEBUST="${CACHEBUST}" .


### PR DESCRIPTION
There was an issue where the delpyment's branch/tag used for `--api` or `--frontend` would default to `LATEST` if it was mistyped or didn't fit the "rule". It was a silent error and is resolved with this patch.

Now, when deploying `LATEST` it will fetch the trunk; otherwise, the specified tag is pulled and included in the image. If the tag does not exist the build will fail. The branch/tags no longer require matching regex 'LATEST|^[0-9v]'.

Resolve #69 