### PR TITLE
FE container listen on port 3000

### DIFF
--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -19,5 +19,5 @@ docker run \
   --name maproulette-frontend \
   --network mrnet \
   --restart unless-stopped \
-  -p 3000:80 \
+  -p 3000:3000 \
   maproulette/maproulette-frontend:"${IMAGE_TAG}"

--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -2,8 +2,8 @@ upstream api {
     server maproulette-api:9000;
 }
 server {
-    listen 80 default_server;
-    listen [::]:80;
+    listen 3000 default_server;
+    listen [::]:3000;
 
     client_max_body_size 100M;
     rewrite ^/mr3/?(.*)$ /$1 permanent;


### PR DESCRIPTION
Simplify the container deployments by not using privileged ports (:80). Some deployments may have an issue and will need this added to the nginx.conf:
```
    # Remove legacy 'mr3' from the URL, if it exists
    rewrite ^/mr3/?(.*)$ /$1 permanent;
```