### PR TITLE
Remove docker run '-it' flags

### DIFF
--- a/api/docker-start.sh
+++ b/api/docker-start.sh
@@ -14,7 +14,7 @@ fi
 
 echo "Starting maproulette api container"
 docker run \
-  -itd \
+  -d \
   --name maproulette-api \
   --network mrnet \
   --restart unless-stopped \

--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -15,7 +15,7 @@ fi
 
 echo "Starting maproulette frontend container"
 docker run \
-  -itd \
+  -d \
   --name maproulette-frontend \
   --network mrnet \
   --restart unless-stopped \


### PR DESCRIPTION
The service doesn't need a TTY and it causes log messages sent to journald to be binary blobs.