### PR TITLE
Add 'Use Host Network' Option to Deployment Script

### DIFF
--- a/api/docker-start.sh
+++ b/api/docker-start.sh
@@ -6,6 +6,12 @@ export VERSION=$1
 # Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
 export IMAGE_TAG=${VERSION//\//-}
 
+if [[ "${USE_HOST_NETWORK}" == "true" ]]; then
+  dockerNetworkArg="--network=host"
+else
+  dockerNetworkArg="--network mrnet -p 9000:9000"
+fi
+
 if [ "$(docker ps -qa -f name=maproulette-api)" ]; then
   echo "Removing existing maproulette-api container"
   docker stop maproulette-api
@@ -15,8 +21,7 @@ fi
 echo "Starting maproulette api container"
 docker run \
   -d \
+  "${dockerNetworkArg}" \
   --name maproulette-api \
-  --network mrnet \
   --restart unless-stopped \
-  -p 9000:9000 \
   maproulette/maproulette-api:"${IMAGE_TAG}"

--- a/conf.template.sh
+++ b/conf.template.sh
@@ -23,6 +23,9 @@
 # The Git location for the API
 # apiGit="git:maproulette/maproulette-backend"
 
+# Whether the docker containers should use the host network
+# useHostNetwork=false
+
 # Whether to wipe the docker database, start clean
 # wipeDB=false
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@ set -exuo pipefail
 
 # Print usage information if -h or --help flags are used
 if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
+    set +x
     echo "Usage: ./deploy.sh [OPTION]..."
     echo "Automated script for deploying the MapRoulette application with frontend, API, and PostGIS database."
     echo ""
@@ -20,6 +21,7 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
     echo "  --wipeDB             Optional. Wipe the Docker database. Default: false."
     echo "  --dbExternal         Optional. Specify if the database is external. Default: false."
     echo "  --buildOnly          Optional. Specify if only build the Docker images without deploying them. Default: false."
+    echo "  --useHostNetwork     Optional. Use host network for Docker. Default: false."
     echo "  -h, --help           Display this help and exit."
     exit 0
 fi
@@ -50,6 +52,9 @@ apiRelease=${apiRelease:-LATEST}
 
 # The git location for the API
 apiGit=${apiGit:-"git:maproulette/maproulette-backend"}
+
+# Whether the docker containers should use the host network
+useHostNetwork=${useHostNetwork:-false}
 
 # Whether to wipe the docker database, start clean
 wipeDB=${wipeDB:-false}
@@ -123,6 +128,9 @@ while true; do
                 break
             done
         ;;
+        --useHostNetwork)
+            useHostNetwork=true
+        ;;
         --dbPort)
             dbPort="$2"
             shift
@@ -143,6 +151,8 @@ while true; do
     shift
 done
 set -u
+
+export USE_HOST_NETWORK="$useHostNetwork"
 
 echo "Building MR Network"
 docker network create --driver bridge mrnet || true

--- a/frontend/docker-start.sh
+++ b/frontend/docker-start.sh
@@ -7,6 +7,12 @@ export VERSION=${VERSION:-$1}
 # Git branches may contains forward slashes and that don't work with docker. Replace any slashes with a dash.
 export IMAGE_TAG=${VERSION//\//-}
 
+if [[ "${USE_HOST_NETWORK}" == "true" ]]; then
+  dockerNetworkArg="--network=host"
+else
+  dockerNetworkArg="--network mrnet -p 3000:3000"
+fi
+
 if [ "$(docker ps -qa -f name=maproulette-frontend)" ]; then
   echo "Removing existing maproulette-frontend container"
   docker stop maproulette-frontend
@@ -16,8 +22,7 @@ fi
 echo "Starting maproulette frontend container"
 docker run \
   -d \
+  "${dockerNetworkArg}" \
   --name maproulette-frontend \
-  --network mrnet \
   --restart unless-stopped \
-  -p 3000:3000 \
   maproulette/maproulette-frontend:"${IMAGE_TAG}"

--- a/frontend/docker.sh
+++ b/frontend/docker.sh
@@ -26,6 +26,12 @@ if [ "$VERSION" = "LATEST" ]; then
     CACHEBUST=$(git ls-remote https://github.com/maproulette/maproulette3.git | grep HEAD | cut -f 1)
 fi
 
+# If the container is using the host network, replace the nginx-config server to use localhost
+if [[ "${USE_HOST_NETWORK}" == "true" ]]; then
+  echo "Replacing the nginx-config server to use localhost"
+  sed -i 's/server maproulette-api:9000;/server 127.0.0.1:9000;/g' nginx-config
+fi
+
 echo "Building container image for MapRoulette frontend Version: $IMAGE_TAG, Repo: ${git[1]}"
 docker build \
     --pull \


### PR DESCRIPTION
Added a 'use host network' option (--useHostNetwork) to the deployment script. This option allows Docker to use the host network for the mr-postgis container instead of the default bridged network.
When this option is used, the script will apply the '--network=host' Docker argument instead of '-p <ports> --network mrnet'.