### PR TITLE
Update to node 18, nginx 1.25, sbt 1.9.7

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 ARG TEMURIN_JDK_TAG=11
-FROM eclipse-temurin:${TEMURIN_JDK_TAG} as builder
+FROM docker.io/library/eclipse-temurin:${TEMURIN_JDK_TAG} as builder
 
-ARG SBT_VERSION=1.7.2
+ARG SBT_VERSION=1.9.7
 ARG CACHEBUST=1
 ARG GIT="maproulette/maproulette-backend"
 ARG VERSION="LATEST"
@@ -35,7 +35,7 @@ RUN \
     sbt clean compile dist && \
     unzip -d / target/universal/MapRouletteAPI.zip
 
-FROM eclipse-temurin:${TEMURIN_JDK_TAG}
+FROM docker.io/library/eclipse-temurin:${TEMURIN_JDK_TAG}
 
 # Runtime image needs to have the most up-to-date patches
 RUN \

--- a/deploy.sh
+++ b/deploy.sh
@@ -177,6 +177,7 @@ if [[ "$api" = true ]]; then
         else
             # The mr-postgis container does not exist. Create and run it.
             echo "Running new mr-postgis container"
+            mkdir -p postgres-data
             docker run \
                 -d \
                 -p "$dbPort":5432 \
@@ -188,7 +189,7 @@ if [[ "$api" = true ]]; then
                 -e POSTGRES_USER=mrdbuser \
                 -e POSTGRES_PASSWORD=mrdbpass \
                 --volume "$(pwd)/postgres-data":/var/lib/postgresql/data \
-                postgis/postgis:11-2.5
+                postgis/postgis:13-3.3
         fi
     fi
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-ARG NODE_TAG=16-bullseye
-ARG NGINX_TAG=1.24-alpine
-FROM node:${NODE_TAG} as builder
+ARG NODE_TAG=18-bullseye
+ARG NGINX_TAG=1.25-alpine
+FROM docker.io/library/node:${NODE_TAG} as builder
 
 ARG GIT="maproulette/maproulette3"
 ARG CACHEBUST=2
@@ -33,10 +33,10 @@ COPY customLayers.json ./src/customLayers.json
 # Build the Maproulette Frontend
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 RUN \
-    yarn && \
-    yarn run build
+    yarn --network-timeout 100000 && \
+    yarn --network-timeout 100000 run build
 
-FROM nginx:${NGINX_TAG}
+FROM docker.io/library/nginx:${NGINX_TAG}
 
 COPY nginx-config /etc/nginx/sites-enabled/maproulette
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Updates:
- Node 18: the old version of node was out of support (end of life'd)
- Nginx 1.25: this is the latest nginx mainline (it's suggested to use the latest mainline)
- sbt 1.9.7