### PR TITLE
Resolve favicon not found

### DIFF
--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -19,7 +19,7 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_http_version 1.1;
     }
-    location ~ (/api/|/auth/|/docs/|/assets/) {
+    location ~ (/api/|/auth/|/docs/) {
         proxy_pass http://api;
 
         include mime.types;


### PR DESCRIPTION
When some browsers load maproulette, the '/assets' route is sent to the API and results in the favicon not being found (http 404). The deployment scripts shouldn't be sending '/assets' to the API and should instead get the assets from the frontend container.

This resolves the missing favicon. See https://github.com/maproulette/maproulette3/issues/2202

Sample requests before and after the fix, the favicon is found :sunglasses: 
![image](https://github.com/maproulette/maproulette2-docker/assets/1300188/0e2094df-77e5-48da-881e-eda73d176928)
