### PR TITLE
Add Cache-Control: public, no-transform to static assets

### DIFF
--- a/frontend/nginx-config
+++ b/frontend/nginx-config
@@ -19,7 +19,7 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_http_version 1.1;
     }
-    location ~ (/api/|/auth/|/docs/|/assets/lib/|/assets/swagger.json) {
+    location ~ ^(/api/|/auth/|/docs/|/assets/lib/|/assets/swagger.json) {
         proxy_pass http://api;
 
         include mime.types;
@@ -34,5 +34,9 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
+    }
+    location ~ ^(/assets/|/static/) {
+        root /var/www/maproulette;
+        add_header Cache-Control "public, no-transform";
     }
 }


### PR DESCRIPTION
This prevents Cloudflare from injecting their tracking beacon into HTML pages served from these directories (which was breaking the [Rapid iframe](https://github.com/maproulette/maproulette3/pull/2403)).

See:
- https://developers.cloudflare.com/cache/concepts/cache-control/ 
- https://developers.cloudflare.com/web-analytics/get-started/#sites-proxied-through-cloudflare